### PR TITLE
feat: お問い合わせ直接送信と基本SEO設定を追加

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { SITE_NAME, getSiteUrl } from "@/lib/constants/site";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -13,8 +14,36 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "就活AI Copilot | MVP",
-  description: "ES添削・企業管理・タスク進捗をAIで支援し、前向きに就活を進めるためのMVP版Webアプリ。",
+  metadataBase: new URL(getSiteUrl()),
+  title: {
+    default: `${SITE_NAME} | 就活を整理して前進する`,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description:
+    "自己分析・適性チェック・ES管理・企業管理・面接ログを1つにまとめ、就活で次にやるべき行動を明確にするWebアプリ。",
+  applicationName: SITE_NAME,
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    locale: "ja_JP",
+    url: "/",
+    siteName: SITE_NAME,
+    title: `${SITE_NAME} | 就活を整理して前進する`,
+    description:
+      "自己分析・適性チェック・ES管理・企業管理・面接ログを1つにまとめ、就活で次にやるべき行動を明確にするWebアプリ。",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${SITE_NAME} | 就活を整理して前進する`,
+    description:
+      "自己分析・適性チェック・ES管理・企業管理・面接ログを1つにまとめ、就活で次にやるべき行動を明確にするWebアプリ。",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,14 @@
+import type { MetadataRoute } from "next";
+import { getSiteUrl } from "@/lib/constants/site";
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = getSiteUrl();
+
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+import { getSiteUrl } from "@/lib/constants/site";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = getSiteUrl();
+  const now = new Date();
+
+  return [
+    {
+      url: `${baseUrl}/`,
+      lastModified: now,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+  ];
+}

--- a/lib/constants/site.ts
+++ b/lib/constants/site.ts
@@ -1,0 +1,19 @@
+const fallbackUrl = "https://job-seeker-gray.vercel.app";
+
+export function getSiteUrl() {
+  const envUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    process.env.NEXT_PUBLIC_VERCEL_URL ||
+    process.env.VERCEL_PROJECT_PRODUCTION_URL ||
+    "";
+
+  if (!envUrl) return fallbackUrl;
+
+  if (envUrl.startsWith("http://") || envUrl.startsWith("https://")) {
+    return envUrl.replace(/\/+$/, "");
+  }
+
+  return `https://${envUrl.replace(/\/+$/, "")}`;
+}
+
+export const SITE_NAME = "就活copilot";


### PR DESCRIPTION
## 変更内容
- お問い合わせフォームをmailto方式からアプリ内直接送信へ変更
- 認証ユーザー情報（登録ユーザー名/ログインメール）を含めて送信
- contact APIを追加（nodemailer利用）
- 送信状態表示の不整合を解消
- 基本SEO設定を追加（metadata/canonical/OG/Twitter）
- sitemap/robotsを追加

## 追加ファイル
- app/api/contact/route.ts
- app/contact/page.tsx
- app/contact/_components/contact-form.tsx
- lib/validation/schemas/contact.ts
- app/sitemap.ts
- app/robots.ts
- lib/constants/site.ts

## 確認
- npm run type-check 実行済み
