### PR TITLE
fix: replace any with Database type in supabase-server.ts (#76)

### DIFF
--- a/app/api/aptitude/answers/route.ts
+++ b/app/api/aptitude/answers/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import { createSupabaseServerActionClient } from "@/lib/supabase/supabase-server";
 import { answersPayloadSchema } from "@/lib/validation/schemas/api";
 import { awardXp } from "@/lib/xp/award-xp";
+import type { Json } from "@/lib/database.types";
 
 export async function POST(req: NextRequest) {
   const supabase = await createSupabaseServerActionClient();
@@ -42,7 +43,7 @@ export async function POST(req: NextRequest) {
     .from("aptitude_results")
     .insert({
       user_id: userData.user.id,
-      answers: payloadValidation.data.answers,
+      answers: payloadValidation.data.answers as Json,
     })
     .select("id")
     .maybeSingle();

--- a/app/api/self-analysis/answers/route.ts
+++ b/app/api/self-analysis/answers/route.ts
@@ -3,6 +3,7 @@ import { revalidatePath } from "next/cache";
 import { createSupabaseServerActionClient } from "@/lib/supabase/supabase-server";
 import { awardXp } from "@/lib/xp/award-xp";
 import { answersPayloadSchema } from "@/lib/validation/schemas/api";
+import type { Json } from "@/lib/database.types";
 
 export async function POST(req: NextRequest) {
   const supabase = await createSupabaseServerActionClient();
@@ -40,7 +41,7 @@ export async function POST(req: NextRequest) {
 
   const { data, error } = await supabase
     .from("self_analysis_results")
-    .insert({ user_id: userData.user.id, answers: payloadValidation.data.answers })
+    .insert({ user_id: userData.user.id, answers: payloadValidation.data.answers as Json })
     .select("id")
     .maybeSingle();
 

--- a/app/es/[id]/page.tsx
+++ b/app/es/[id]/page.tsx
@@ -50,7 +50,7 @@ export default async function EsDetailPage({
   const supabase = await createSupabaseReadonlyClient();
   if (!supabase) throw new Error("Supabase client unavailable");
   const { data: userData } = await supabase.auth.getUser();
-  const userId = userData?.user?.id ?? null;
+  const userId = userData.user!.id;
 
   const { data, error } = await supabase
     .from("es_entries")

--- a/lib/supabase/supabase-server.ts
+++ b/lib/supabase/supabase-server.ts
@@ -1,7 +1,5 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { createServerClient } from "@supabase/ssr";
-import { createClient } from "@supabase/supabase-js";
-import { SupabaseClient } from "@supabase/supabase-js";
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
 import { Database } from "@/lib/database.types";
 
@@ -14,31 +12,30 @@ const getEnv = () => {
   return { supabaseUrl, supabaseAnonKey };
 };
 
-export const createSupabaseServerReadonlyClient = async (): Promise<SupabaseClient<any>> => {
+export const createSupabaseServerReadonlyClient = async (): Promise<SupabaseClient<Database>> => {
   const { supabaseUrl, supabaseAnonKey } = getEnv();
   const cookieStore = await cookies();
-  return createServerClient<any>(supabaseUrl, supabaseAnonKey, {
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
-      get(name: string) {
-        return cookieStore.get(name)?.value;
+      getAll() {
+        return cookieStore.getAll();
       },
     },
   });
 };
 
-export const createSupabaseServerActionClient = async (): Promise<SupabaseClient<any>> => {
+export const createSupabaseServerActionClient = async (): Promise<SupabaseClient<Database>> => {
   const { supabaseUrl, supabaseAnonKey } = getEnv();
   const cookieStore = await cookies();
-  return createServerClient<any>(supabaseUrl, supabaseAnonKey, {
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
     cookies: {
-      get(name: string) {
-        return cookieStore.get(name)?.value;
+      getAll() {
+        return cookieStore.getAll();
       },
-      set(name: string, value: string, options?: { path?: string }) {
-        cookieStore.set(name, value, { path: options?.path ?? "/" });
-      },
-      remove(name: string, options?: { path?: string }) {
-        cookieStore.set(name, "", { path: options?.path ?? "/", expires: new Date(0) });
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value, options }) =>
+          cookieStore.set(name, value, options)
+        );
       },
     },
   });


### PR DESCRIPTION
## Summary

- `lib/supabase/supabase-server.ts` の `SupabaseClient<any>` / `createServerClient<any>` を `Database` 型に置き換え
- `eslint-disable @typescript-eslint/no-explicit-any` コメントを削除
- Cookie API を `get/set/remove` から `getAll/setAll` 形式に更新（`@supabase/ssr@0.12.0` 推奨形式）
- `any` 型の除去によって顕在化した潜在的な型エラーを修正

## 型エラーの修正詳細

| ファイル | 問題 | 修正 |
|---|---|---|
| `app/api/aptitude/answers/route.ts` | `Record<string, unknown>` が `Json` 型に非代入 | `as Json` キャストを追加 |
| `app/api/self-analysis/answers/route.ts` | 同上 | 同上 |
| `app/es/[id]/page.tsx` | `string \| null` が `.eq()` の `string` 引数に非代入 | `userData.user!.id` に変更 |

## 背景

`any` 型は `@supabase/ssr@0.5.x` の型定義が不十分だったための回避策として導入されていた。`@supabase/ssr@0.12.0` へのアップグレード（PR #75）により `Database` 型が正しく機能するようになったため、`any` を除去できる状態になった。

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)