### PR TITLE
refactor: unify duplicate Zod schemas into idAndSummarySchema (#70)

### DIFF
--- a/app/api/ai/interview/route.ts
+++ b/app/api/ai/interview/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { createSupabaseServerActionClient } from "@/lib/supabase/supabase-server";
-import { idAndOptionalSummarySchema } from "@/lib/validation/schemas/ai";
+import { idAndSummarySchema } from "@/lib/validation/schemas/ai";
 
 export async function POST(request: Request) {
   const supabase = await createSupabaseServerActionClient();
@@ -9,7 +9,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
   const body = await request.json().catch(() => null);
-  const requestValidation = idAndOptionalSummarySchema.safeParse(body);
+  const requestValidation = idAndSummarySchema.safeParse(body);
   if (!requestValidation.success)
     return NextResponse.json(
       { error: "id and summary are required" },

--- a/app/api/company-ai-save/route.ts
+++ b/app/api/company-ai-save/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { idAndSummaryStringSchema } from "@/lib/validation/schemas/ai";
+import { idAndSummarySchema } from "@/lib/validation/schemas/ai";
 import { createSupabaseActionClient } from "@/lib/supabase/supabase-server";
 
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json().catch(() => null);
-    const requestValidation = idAndSummaryStringSchema.safeParse(body);
+    const requestValidation = idAndSummarySchema.safeParse(body);
     if (!requestValidation.success) {
       return NextResponse.json({ error: "id and summary are required" }, { status: 400 });
     }

--- a/lib/validation/schemas/ai.ts
+++ b/lib/validation/schemas/ai.ts
@@ -9,13 +9,3 @@ export const idAndSummarySchema = z.object({
   id: z.string().min(1),
   summary: z.string().min(1),
 });
-
-export const idAndOptionalSummarySchema = z.object({
-  id: z.string().min(1),
-  summary: z.string().min(1),
-});
-
-export const idAndSummaryStringSchema = z.object({
-  id: z.string().min(1),
-  summary: z.string().min(1),
-});


### PR DESCRIPTION
## Summary

- `lib/validation/schemas/ai.ts` に存在していた内容が完全に同一のスキーマ3つを1つに統合
- `idAndOptionalSummarySchema` と `idAndSummaryStringSchema` を削除
- 使用箇所を `idAndSummarySchema` に統一

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `lib/validation/schemas/ai.ts` | 重複スキーマ2つを削除 |
| `app/api/ai/interview/route.ts` | import を `idAndSummarySchema` に変更 |
| `app/api/company-ai-save/route.ts` | import を `idAndSummarySchema` に変更 |

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)