### PR TITLE
refactor: forwardRefを削除しReact 19のref propに移行 (#81)

### DIFF
--- a/app/_components/ui/Button.tsx
+++ b/app/_components/ui/Button.tsx
@@ -1,54 +1,46 @@
-import { forwardRef } from "react";
 import { clsx } from "clsx";
 
 export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "default" | "primary" | "ghost" | "destructive";
   size?: "sm" | "md" | "lg";
+  ref?: React.Ref<HTMLButtonElement>;
 }
 
-export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = "default", size = "md", ...props }, ref) => {
-    return (
-      <button
-        className={clsx(
-          // Base styles
-          "inline-flex items-center justify-center gap-2 rounded-md border font-medium transition-all duration-100",
-          "disabled:pointer-events-none disabled:opacity-50",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-1",
+export const Button = ({ className, variant = "default", size = "md", ref, ...props }: ButtonProps) => {
+  return (
+    <button
+      className={clsx(
+        // Base styles
+        "inline-flex items-center justify-center gap-2 rounded-md border font-medium transition-all duration-100",
+        "disabled:pointer-events-none disabled:opacity-50",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-1",
 
-          // Variant styles
-          {
-            // Default
-            "border-sky-100 bg-white text-slate-900 hover:border-sky-200 hover:bg-sky-50":
-              variant === "default",
+        // Variant styles
+        {
+          // Default
+          "border-sky-100 bg-white text-slate-900 hover:border-sky-200 hover:bg-sky-50": variant === "default",
 
-            // Primary
-            "border-sky-500 bg-sky-500 text-white hover:border-sky-400 hover:bg-sky-400":
-              variant === "primary",
+          // Primary
+          "border-sky-500 bg-sky-500 text-white hover:border-sky-400 hover:bg-sky-400": variant === "primary",
 
-            // Ghost
-            "border-transparent bg-transparent text-sky-700 hover:bg-sky-50 hover:text-sky-500":
-              variant === "ghost",
+          // Ghost
+          "border-transparent bg-transparent text-sky-700 hover:bg-sky-50 hover:text-sky-500": variant === "ghost",
 
-            // Destructive
-            "border-rose-500 bg-rose-500 text-white hover:border-rose-400 hover:bg-rose-400":
-              variant === "destructive",
-          },
+          // Destructive
+          "border-rose-500 bg-rose-500 text-white hover:border-rose-400 hover:bg-rose-400": variant === "destructive",
+        },
 
-          // Size styles
-          {
-            "h-7 px-2 text-xs": size === "sm",
-            "h-8 px-3 text-sm": size === "md",
-            "h-10 px-4 text-base": size === "lg",
-          },
+        // Size styles
+        {
+          "h-7 px-2 text-xs": size === "sm",
+          "h-8 px-3 text-sm": size === "md",
+          "h-10 px-4 text-base": size === "lg",
+        },
 
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
-);
-
-Button.displayName = "Button";
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+};

--- a/app/_components/ui/Card.tsx
+++ b/app/_components/ui/Card.tsx
@@ -1,80 +1,85 @@
-import { forwardRef } from "react";
 import { clsx } from "clsx";
 
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   variant?: "default" | "elevated" | "outlined";
   padding?: "none" | "sm" | "md" | "lg";
   hover?: boolean;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-export const Card = forwardRef<HTMLDivElement, CardProps>(
-  ({ className, variant = "default", padding = "md", hover = false, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className={clsx(
-          // Base styles
-          "rounded-sm bg-white border transition-all duration-100",
+export const Card = ({ className, variant = "default", padding = "md", hover = false, ref, ...props }: CardProps) => {
+  return (
+    <div
+      ref={ref}
+      className={clsx(
+        // Base styles
+        "rounded-sm bg-white border transition-all duration-100",
 
-          // Variant styles
-          {
-            "border-(--border-light) shadow-(--shadow-subtle)": variant === "default",
-            "border-(--border-light) shadow-(--shadow-medium)": variant === "elevated",
-            "border-(--border-medium) shadow-none": variant === "outlined",
-          },
+        // Variant styles
+        {
+          "border-(--border-light) shadow-(--shadow-subtle)": variant === "default",
+          "border-(--border-light) shadow-(--shadow-medium)": variant === "elevated",
+          "border-(--border-medium) shadow-none": variant === "outlined",
+        },
 
-          // Hover effect
-          {
-            "hover:shadow-(--shadow-medium) cursor-pointer": hover && variant === "default",
-            "hover:shadow-(--shadow-strong) cursor-pointer": hover && variant === "elevated",
-            "hover:border-(--border-medium) cursor-pointer": hover && variant === "outlined",
-          },
+        // Hover effect
+        {
+          "hover:shadow-(--shadow-medium) cursor-pointer": hover && variant === "default",
+          "hover:shadow-(--shadow-strong) cursor-pointer": hover && variant === "elevated",
+          "hover:border-(--border-medium) cursor-pointer": hover && variant === "outlined",
+        },
 
-          // Padding styles
-          {
-            "p-0": padding === "none",
-            "p-3": padding === "sm",
-            "p-4": padding === "md",
-            "p-6": padding === "lg",
-          },
+        // Padding styles
+        {
+          "p-0": padding === "none",
+          "p-3": padding === "sm",
+          "p-4": padding === "md",
+          "p-6": padding === "lg",
+        },
 
-          className,
-        )}
-        {...props}
-      />
-    );
-  },
+        className,
+      )}
+      {...props}
+    />
+  );
+};
+
+export const CardHeader = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) => (
+  <div ref={ref} className={clsx("flex flex-col space-y-1.5", className)} {...props} />
 );
 
-Card.displayName = "Card";
-
-export const CardHeader = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={clsx("flex flex-col space-y-1.5", className)} {...props} />
-  ),
+export const CardTitle = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLHeadingElement> & { ref?: React.Ref<HTMLHeadingElement> }) => (
+  <h3 ref={ref} className={clsx("font-medium leading-none tracking-tight text-foreground", className)} {...props} />
 );
-CardHeader.displayName = "CardHeader";
 
-export const CardTitle = forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={clsx("font-medium leading-none tracking-tight text-foreground", className)} {...props} />
-  ),
+export const CardDescription = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLParagraphElement> & { ref?: React.Ref<HTMLParagraphElement> }) => (
+  <p ref={ref} className={clsx("text-sm text-(--foreground-secondary)", className)} {...props} />
 );
-CardTitle.displayName = "CardTitle";
 
-export const CardDescription = forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => (
-    <p ref={ref} className={clsx("text-sm text-(--foreground-secondary)", className)} {...props} />
-  ),
+export const CardContent = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) => (
+  <div ref={ref} className={clsx("pt-0", className)} {...props} />
 );
-CardDescription.displayName = "CardDescription";
 
-export const CardContent = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={clsx("pt-0", className)} {...props} />,
+export const CardFooter = ({
+  className,
+  ref,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> & { ref?: React.Ref<HTMLDivElement> }) => (
+  <div ref={ref} className={clsx("flex items-center pt-0", className)} {...props} />
 );
-CardContent.displayName = "CardContent";
-
-export const CardFooter = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => <div ref={ref} className={clsx("flex items-center pt-0", className)} {...props} />,
-);
-CardFooter.displayName = "CardFooter";


### PR DESCRIPTION
Closes #81

## Summary
- `app/_components/ui/Card.tsx` の6コンポーネント(Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter)から `forwardRef` ラッパーと `displayName` を削除し、React 19の ref-as-prop に移行
- `app/_components/ui/Button.tsx` も同様に移行
- `CardTitle` の ref型が要素(`<h3>`)と不一致(`HTMLParagraphElement`)だったのを `HTMLHeadingElement` に修正

## Note
- `ui/Card` / `ui/Button` は現時点でどこからもimportされていない未使用コンポーネントのため、呼び出し側への影響はありません(UIライブラリ導入Issue #91での扱い検討対象)

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`(既存warningのみ、新規errorなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)