### PR TITLE
refactor: useEffectによるstate同期アンチパターンを排除 (#83)

### DIFF
--- a/app/es/_components/ai-es-panel.tsx
+++ b/app/es/_components/ai-es-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 import { AiPanel } from "@/app/_components/ai-panel";
 
@@ -28,8 +28,7 @@ export function EsAiPanel({
   defaultTitle,
 }: Props) {
   const [presetKey, setPresetKey] = useState<string | undefined>(undefined);
-  const [presetText, setPresetText] = useState<string>("");
-  const [saved, setSaved] = useState(false);
+  const [userSaved, setUserSaved] = useState(false);
 
   const aiInput = useMemo(() => {
     const meta = [
@@ -41,15 +40,8 @@ export function EsAiPanel({
     return [...meta, content].filter(Boolean).join("\n\n");
   }, [content, defaultCompanyName, defaultStatus, defaultCompanyUrl, defaultTitle]);
 
-  useEffect(() => {
-    setPresetText(aiInput);
-  }, [aiInput]);
-
-  useEffect(() => {
-    if (initialSummary) {
-      setSaved(true);
-    }
-  }, [initialSummary]);
+  // 保存済みかどうかは props（initialSummary）とユーザー操作（保存完了）からの派生値
+  const saved = userSaved || Boolean(initialSummary);
 
   return (
     <div className="space-y-3">
@@ -58,7 +50,6 @@ export function EsAiPanel({
           type="button"
           onClick={() => {
             if (saved && saveUrl) return;
-            setPresetText(aiInput);
             setPresetKey(`${Date.now()}`);
           }}
           disabled={saved && !!saveUrl}
@@ -71,7 +62,7 @@ export function EsAiPanel({
       <AiPanel
         kind="es_review"
         defaultInput={aiInput}
-        presetText={presetText}
+        presetText={aiInput}
         presetKey={presetKey}
         cacheKey={cacheKey}
         initialSummary={initialSummary}
@@ -79,7 +70,7 @@ export function EsAiPanel({
         saveId={saveId}
         title="AI添削パネル"
         hint="ボタンでES内容を転記してから送信してください。保存後は再実行できません。"
-        onSaved={() => setSaved(true)}
+        onSaved={() => setUserSaved(true)}
       />
     </div>
   );


### PR DESCRIPTION
Closes #83

## Summary
- `app/es/_components/ai-es-panel.tsx`: `setPresetText(aiInput)` の同期useEffectを削除し、`presetText={aiInput}` を直接渡す形に変更
- `saved` は保存操作でもtrueになるため完全な派生値にはできず、最小限のstate `userSaved` + `userSaved || Boolean(initialSummary)` の派生値の組み合わせで、旧実装(JSON パース不能でもtruthyならsaved=trueにする挙動含む)を厳密に維持

## Note
- `app/companies/_components/company-ai-panel.tsx` は#69(Agentic RAG)の書き直しで該当の同期パターンが既に解消されていたため、今回の変更対象から除外(修正不要と判断)

## Test plan
- [x] `npm run type-check`
- [x] `npm run lint`(既存warningのみ、新規errorなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)