### PR TITLE
fix: AIレート制限を永続化しcompany/analyzeにも適用 (#111)

### DIFF
--- a/app/api/ai/company/analyze/route.ts
+++ b/app/api/ai/company/analyze/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { z } from "zod";
 import { createSupabaseServerActionClient } from "@/lib/supabase/supabase-server";
 import { agenticCompanyAnalysis } from "@/lib/ai/agentic-company";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 // SSE（Server-Sent Events）の1イベント形式に整形する。
 // "data: <JSON>\n\n" がブラウザ側でMessageEventとして受信される規格。
@@ -14,11 +15,27 @@ const requestSchema = z.object({
   input: z.string().trim().min(1).max(2000),
 });
 
+// Tavily検索×最大3回+複数回のLLM呼び出しを伴う最もコストの高いAIエンドポイントのため、
+// 通常の/api/aiより厳しめのウィンドウ・上限にする。
+const RATE_LIMIT_WINDOW_MS = 10 * 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+
 export async function POST(req: NextRequest) {
   const supabase = await createSupabaseServerActionClient();
   const { data: userData, error: userError } = await supabase.auth.getUser();
   if (userError || !userData?.user) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const rateLimit = await checkRateLimit(supabase, userData.user.id, "ai_company_analyze", {
+    windowMs: RATE_LIMIT_WINDOW_MS,
+    maxRequests: RATE_LIMIT_MAX_REQUESTS,
+  });
+  if (!rateLimit.allowed) {
+    return new Response(JSON.stringify({ error: "Too many requests. Please try again later." }), {
+      status: 429,
+      headers: { "Retry-After": String(rateLimit.retryAfterSec) },
+    });
   }
 
   const body = await req.json().catch(() => null);

--- a/app/api/ai/route.ts
+++ b/app/api/ai/route.ts
@@ -3,35 +3,10 @@ import { createAiClient } from "@/lib/ai/client";
 import { AiPromptKind } from "@/lib/ai/types";
 import { aiRequestSchema } from "@/lib/validation/schemas/ai";
 import { createSupabaseServerActionClient } from "@/lib/supabase/supabase-server";
+import { checkRateLimit } from "@/lib/rate-limit";
 
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const RATE_LIMIT_MAX_REQUESTS = 12;
-
-const aiRateLimitStore = new Map<string, { count: number; resetAt: number }>();
-
-function checkAiRateLimit(userId: string) {
-  const now = Date.now();
-  const current = aiRateLimitStore.get(userId);
-
-  if (!current || current.resetAt <= now) {
-    aiRateLimitStore.set(userId, {
-      count: 1,
-      resetAt: now + RATE_LIMIT_WINDOW_MS,
-    });
-    return { allowed: true as const, retryAfterSec: 0 };
-  }
-
-  if (current.count >= RATE_LIMIT_MAX_REQUESTS) {
-    return {
-      allowed: false as const,
-      retryAfterSec: Math.ceil((current.resetAt - now) / 1000),
-    };
-  }
-
-  current.count += 1;
-  aiRateLimitStore.set(userId, current);
-  return { allowed: true as const, retryAfterSec: 0 };
-}
 
 export async function POST(req: NextRequest) {
   try {
@@ -41,7 +16,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const rateLimit = checkAiRateLimit(userData.user.id);
+    const rateLimit = await checkRateLimit(supabase, userData.user.id, "ai", {
+      windowMs: RATE_LIMIT_WINDOW_MS,
+      maxRequests: RATE_LIMIT_MAX_REQUESTS,
+    });
     if (!rateLimit.allowed) {
       return NextResponse.json(
         { error: "Too many requests. Please try again later." },

--- a/lib/database.types.ts
+++ b/lib/database.types.ts
@@ -273,6 +273,22 @@ export interface Database {
         Update: Partial<Database["public"]["Tables"]["interview_logs"]["Insert"]>;
         Relationships: [];
       };
+      api_rate_limits: {
+        Row: {
+          user_id: string;
+          bucket: string;
+          window_start: string;
+          count: number;
+        };
+        Insert: {
+          user_id: string;
+          bucket: string;
+          window_start?: string;
+          count?: number;
+        };
+        Update: Partial<Database["public"]["Tables"]["api_rate_limits"]["Insert"]>;
+        Relationships: [];
+      };
     };
     Views: Record<string, never>;
     Functions: Record<string, never>;

--- a/lib/rate-limit.test.ts
+++ b/lib/rate-limit.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { createSupabaseMock } from "@/test/helpers/supabase-mock";
+import { checkRateLimit } from "./rate-limit";
+
+const OPTS = { windowMs: 60_000, maxRequests: 3 };
+
+describe("checkRateLimit", () => {
+  it("allows the request and starts a new window when no record exists", async () => {
+    const mock = createSupabaseMock([{ data: null }]);
+
+    const result = await checkRateLimit(mock.client as never, "user-1", "ai", { ...OPTS, now: () => 1_000_000 });
+
+    expect(result).toEqual({ allowed: true, retryAfterSec: 0 });
+    const upsertCall = mock.callsFor("upsert")[0];
+    expect(upsertCall.args[0]).toEqual({
+      user_id: "user-1",
+      bucket: "ai",
+      window_start: new Date(1_000_000).toISOString(),
+      count: 1,
+    });
+  });
+
+  it("starts a new window when the previous one has expired", async () => {
+    const windowStart = new Date(1_000_000).toISOString();
+    const mock = createSupabaseMock([{ data: { window_start: windowStart, count: 3 } }]);
+
+    const result = await checkRateLimit(mock.client as never, "user-1", "ai", {
+      ...OPTS,
+      now: () => 1_000_000 + OPTS.windowMs,
+    });
+
+    expect(result).toEqual({ allowed: true, retryAfterSec: 0 });
+  });
+
+  it("allows and increments the count while under the limit", async () => {
+    const windowStart = new Date(1_000_000).toISOString();
+    const mock = createSupabaseMock([{ data: { window_start: windowStart, count: 1 } }]);
+
+    const result = await checkRateLimit(mock.client as never, "user-1", "ai", { ...OPTS, now: () => 1_000_500 });
+
+    expect(result).toEqual({ allowed: true, retryAfterSec: 0 });
+    const updateCall = mock.callsFor("update")[0];
+    expect(updateCall.args[0]).toEqual({ count: 2 });
+  });
+
+  it("denies the request once the limit is reached within the window", async () => {
+    const windowStart = new Date(1_000_000).toISOString();
+    const mock = createSupabaseMock([{ data: { window_start: windowStart, count: 3 } }]);
+
+    const result = await checkRateLimit(mock.client as never, "user-1", "ai", { ...OPTS, now: () => 1_030_000 });
+
+    expect(result.allowed).toBe(false);
+    expect(result.retryAfterSec).toBe(30);
+  });
+});

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,0 +1,60 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "@/lib/database.types";
+
+type Client = SupabaseClient<Database>;
+
+export type RateLimitResult = { allowed: boolean; retryAfterSec: number };
+
+export type RateLimitOptions = {
+  windowMs: number;
+  maxRequests: number;
+  // テスト用に現在時刻を注入できるようにする（デフォルトはDate.now）
+  now?: () => number;
+};
+
+// api_rate_limits テーブルに永続化することで、サーバーレス環境の複数インスタンス間でも
+// 一貫したレート制限を行う（従来のin-memory Mapはインスタンスごとに独立し、コールドスタートで
+// リセットされてしまうため実効性が弱かった）。
+export async function checkRateLimit(
+  supabase: Client,
+  userId: string,
+  bucket: string,
+  { windowMs, maxRequests, now = Date.now }: RateLimitOptions,
+): Promise<RateLimitResult> {
+  const nowMs = now();
+
+  const { data: existing } = await supabase
+    .from("api_rate_limits")
+    .select("window_start, count")
+    .eq("user_id", userId)
+    .eq("bucket", bucket)
+    .maybeSingle();
+
+  const windowStartMs = existing ? new Date(existing.window_start).getTime() : 0;
+  const windowExpired = !existing || nowMs - windowStartMs >= windowMs;
+
+  if (windowExpired) {
+    await supabase.from("api_rate_limits").upsert({
+      user_id: userId,
+      bucket,
+      window_start: new Date(nowMs).toISOString(),
+      count: 1,
+    });
+    return { allowed: true, retryAfterSec: 0 };
+  }
+
+  if (existing.count >= maxRequests) {
+    return {
+      allowed: false,
+      retryAfterSec: Math.max(0, Math.ceil((windowStartMs + windowMs - nowMs) / 1000)),
+    };
+  }
+
+  await supabase
+    .from("api_rate_limits")
+    .update({ count: existing.count + 1 })
+    .eq("user_id", userId)
+    .eq("bucket", bucket);
+
+  return { allowed: true, retryAfterSec: 0 };
+}

--- a/supabase/migrations/add_api_rate_limits.sql
+++ b/supabase/migrations/add_api_rate_limits.sql
@@ -1,0 +1,31 @@
+-- issue#111: AIエンドポイントのレート制限をサーバーレス環境でも一貫させるため、
+-- これまでのin-memory Mapから永続化テーブルへ移行する。
+
+create table if not exists public.api_rate_limits (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  bucket text not null,
+  window_start timestamptz not null default now(),
+  count integer not null default 0,
+  primary key (user_id, bucket)
+);
+
+alter table public.api_rate_limits enable row level security;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='api_rate_limits' and policyname='Enable read own rate limits'
+  ) then
+    create policy "Enable read own rate limits" on public.api_rate_limits for select using (auth.uid() = user_id);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='api_rate_limits' and policyname='Enable insert own rate limits'
+  ) then
+    create policy "Enable insert own rate limits" on public.api_rate_limits for insert with check (auth.uid() = user_id);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='api_rate_limits' and policyname='Enable update own rate limits'
+  ) then
+    create policy "Enable update own rate limits" on public.api_rate_limits for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+  end if;
+end$$;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -148,6 +148,17 @@ create table if not exists public.interview_logs (
 
 alter table public.interview_logs enable row level security;
 
+-- APIレート制限（in-memory Mapからの移行。サーバーレス環境でインスタンス間の状態を共有するため）
+create table if not exists public.api_rate_limits (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  bucket text not null,
+  window_start timestamptz not null default now(),
+  count integer not null default 0,
+  primary key (user_id, bucket)
+);
+
+alter table public.api_rate_limits enable row level security;
+
 do $$
 begin
   -- profiles
@@ -358,5 +369,22 @@ begin
     select 1 from pg_policies where schemaname='public' and tablename='webtest_attempts' and policyname='Enable delete own webtest attempts'
   ) then
     create policy "Enable delete own webtest attempts" on public.webtest_attempts for delete using (auth.uid() = user_id);
+  end if;
+
+  -- api_rate_limits
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='api_rate_limits' and policyname='Enable read own rate limits'
+  ) then
+    create policy "Enable read own rate limits" on public.api_rate_limits for select using (auth.uid() = user_id);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='api_rate_limits' and policyname='Enable insert own rate limits'
+  ) then
+    create policy "Enable insert own rate limits" on public.api_rate_limits for insert with check (auth.uid() = user_id);
+  end if;
+  if not exists (
+    select 1 from pg_policies where schemaname='public' and tablename='api_rate_limits' and policyname='Enable update own rate limits'
+  ) then
+    create policy "Enable update own rate limits" on public.api_rate_limits for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
   end if;
 end$$;

--- a/test/helpers/supabase-mock.ts
+++ b/test/helpers/supabase-mock.ts
@@ -4,7 +4,7 @@ export type MockQueryResult = { data?: unknown; count?: number | null };
 
 export type SupabaseCallRecord = {
   table: string;
-  method: "select" | "eq" | "gte" | "maybeSingle" | "upsert" | "insert";
+  method: "select" | "eq" | "gte" | "maybeSingle" | "upsert" | "insert" | "update";
   args: unknown[];
 };
 
@@ -52,6 +52,10 @@ export function createSupabaseMock(resultsQueue: MockQueryResult[] = []) {
       },
       insert: (...args: unknown[]) => {
         record("insert", args);
+        return query;
+      },
+      update: (...args: unknown[]) => {
+        record("update", args);
         return query;
       },
       then: (resolve: (value: MockQueryResult) => void, reject: (reason: unknown) => void) => {


### PR DESCRIPTION
## Summary
- `app/api/ai/route.ts` のin-memory Mapによるレート制限を、Supabaseの新テーブル `api_rate_limits`(RLS付き)へ移行
- ロジックを `lib/rate-limit.ts` に切り出し、クロック注入可能にして単体テスト化（4ケース）
- これまでレート制限が無かった `/api/ai/company/analyze`（Tavily検索+複数回LLM呼び出しを伴う最もコストの高いエンドポイント）にも制限を追加（10分間に5回）

Closes #111

## ⚠️ マージ後に必要な手動作業
`supabase/migrations/add_api_rate_limits.sql` を本番Supabaseプロジェクトに適用してください（SQL Editor等で実行）。

**マイグレーション未適用でも壊れません**（`checkRateLimit`はテーブル未検出時のエラーを握りつぶし、fail-open=リクエストを許可する設計のため、レート制限が効かないだけでAI機能自体は動作し続けます）。ただし本来の目的（永続化されたレート制限）を有効にするには適用が必要です。

## Test plan
- [x] `npm run test`（137件green、rate-limit.test.ts 4件追加）
- [x] `npm run type-check`
- [x] `npm run lint`
- [x] `npm run format:check`（対象ファイル）
- [x] `npm run build`
- [ ] マイグレーション適用後、実際にレート制限が機能することを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)