### PR TITLE
test: ES設問パース処理の単体テストを追加

### DIFF
--- a/app/es/actions-utils.ts
+++ b/app/es/actions-utils.ts
@@ -1,0 +1,36 @@
+import { randomUUID } from "crypto";
+import { esQuestionsSchema } from "@/lib/validation/schemas/forms";
+
+type Question = { id: string; prompt: string; answer_md: string };
+
+export function parseQuestions(questionsJson: string | null): Question[] {
+  if (!questionsJson) return [];
+  try {
+    const questionsValue = JSON.parse(questionsJson);
+    const validated = esQuestionsSchema.parse(questionsValue);
+    return validated
+      .map((q) => ({
+        id: typeof q?.id === "string" ? q.id : randomUUID(),
+        prompt: typeof q?.prompt === "string" ? q.prompt : "",
+        answer_md: typeof q?.answer_md === "string" ? q.answer_md : "",
+      }))
+      .filter((q) => q.prompt.trim() || q.answer_md.trim());
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new Error("questions_json must be valid JSON");
+    }
+    throw error;
+  }
+}
+
+export function combineContent(questions: Question[], fallback: string) {
+  if (!questions.length) return fallback;
+  return questions
+    .map((q) => {
+      const prompt = q.prompt?.trim() ?? "";
+      const answer = q.answer_md?.trim() ?? "";
+      return [prompt, answer].filter(Boolean).join("\n");
+    })
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/app/es/actions.test.ts
+++ b/app/es/actions.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { combineContent, parseQuestions } from "./actions-utils";
+
+describe("parseQuestions", () => {
+  it("returns an empty list when questions_json is empty", () => {
+    expect(parseQuestions(null)).toEqual([]);
+    expect(parseQuestions("")).toEqual([]);
+  });
+
+  it("parses valid questions and filters empty entries", () => {
+    const questions = parseQuestions(
+      JSON.stringify([
+        { id: "q1", prompt: "志望理由", answer_md: "成長環境に魅力を感じたため" },
+        { id: "empty", prompt: "  ", answer_md: "" },
+      ]),
+    );
+
+    expect(questions).toEqual([
+      {
+        id: "q1",
+        prompt: "志望理由",
+        answer_md: "成長環境に魅力を感じたため",
+      },
+    ]);
+  });
+
+  it("fills missing optional question fields with safe defaults", () => {
+    const [question] = parseQuestions(JSON.stringify([{ prompt: "自己PR" }]));
+
+    expect(question?.id).toEqual(expect.any(String));
+    expect(question?.prompt).toBe("自己PR");
+    expect(question?.answer_md).toBe("");
+  });
+
+  it("throws a clear error for malformed JSON", () => {
+    expect(() => parseQuestions("{broken")).toThrow("questions_json must be valid JSON");
+  });
+});
+
+describe("combineContent", () => {
+  it("returns fallback content when no questions exist", () => {
+    expect(combineContent([], "既存本文")).toBe("既存本文");
+  });
+
+  it("combines prompt and answer blocks while trimming empty lines", () => {
+    const content = combineContent(
+      [
+        { id: "q1", prompt: " 志望理由 ", answer_md: " 回答1 " },
+        { id: "q2", prompt: "", answer_md: "回答2" },
+      ],
+      "fallback",
+    );
+
+    expect(content).toBe("志望理由\n回答1\n\n回答2");
+  });
+});

--- a/app/es/actions.ts
+++ b/app/es/actions.ts
@@ -1,45 +1,11 @@
 ﻿"use server";
 
-import { randomUUID } from "crypto";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { createSupabaseActionClient } from "@/lib/supabase/supabase-server";
-import { esFormSchema, esQuestionsSchema } from "@/lib/validation/schemas/forms";
+import { esFormSchema } from "@/lib/validation/schemas/forms";
 import { awardXp } from "@/lib/xp/award-xp";
-
-type Question = { id: string; prompt: string; answer_md: string };
-
-function parseQuestions(questionsJson: string | null): Question[] {
-  if (!questionsJson) return [];
-  try {
-    const questionsValue = JSON.parse(questionsJson);
-    const validated = esQuestionsSchema.parse(questionsValue);
-    return validated
-      .map((q) => ({
-        id: typeof q?.id === "string" ? q.id : randomUUID(),
-        prompt: typeof q?.prompt === "string" ? q.prompt : "",
-        answer_md: typeof q?.answer_md === "string" ? q.answer_md : "",
-      }))
-      .filter((q) => q.prompt.trim() || q.answer_md.trim());
-  } catch (error) {
-    if (error instanceof SyntaxError) {
-      throw new Error("questions_json must be valid JSON");
-    }
-    throw error;
-  }
-}
-
-function combineContent(questions: Question[], fallback: string) {
-  if (!questions.length) return fallback;
-  return questions
-    .map((q) => {
-      const prompt = q.prompt?.trim() ?? "";
-      const answer = q.answer_md?.trim() ?? "";
-      return [prompt, answer].filter(Boolean).join("\n");
-    })
-    .filter(Boolean)
-    .join("\n\n");
-}
+import { combineContent, parseQuestions } from "./actions-utils";
 
 export async function createEs(formData: FormData) {
   const supabase = await createSupabaseActionClient();


### PR DESCRIPTION
## 概要

Issue #106 のテスト残債のうち、`app/es/actions.ts` の `parseQuestions` / `combineContent` 相当のロジックを直接テストできるようにしました。

## 変更内容

- Server Actions ファイルから ES 設問処理を `app/es/actions-utils.ts` へ分離
- `app/es/actions.test.ts` を追加
- JSON不正、空設問の除外、optional field の補完、fallback、本文結合を検証

## 確認

- `npm run test -- app/es/actions.test.ts`
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm run format:check`
- `git diff --check`

Part of #106